### PR TITLE
only calculate self sufficiency if vehicles were charged

### DIFF
--- a/src/advantage/simulation_state.py
+++ b/src/advantage/simulation_state.py
@@ -59,7 +59,7 @@ class SimulationState:
 
     def calculate_key_log_parameters(self):
         """Calculates values for the log files."""
-        if self.charging_vehicles:
+        if self.accumulated_results["charging_demand"]:
             self_sufficiency = min(
                 round(
                     self.accumulated_results["energy_from_feed_in"]


### PR DESCRIPTION
When no vehicle is charged the simulation crashes otherwise. Maybe you want to have another solution.
closes #74 